### PR TITLE
Replace hard-coded UI by Glade designed XML

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,17 +1,18 @@
 language: rust
-sudo: false
+sudo: required
+dist: trusty
 env:
   global:
     - LD_LIBRARY_PATH=/usr/local/lib
 rust:
   - nightly
   - stable
-
-addons:
-  apt:
-    packages:
-      - libgtk-3-dev
-
+before_install:
+  - sudo add-apt-repository -y ppa:gnome3-team/gnome3
+  - sudo add-apt-repository -y ppa:gnome3-team/gnome3-staging
+  - sudo apt-get update
+install:
+  - sudo apt-get install -y gtk+3.0 libgtk-3-dev
 script:
   - rustc --version
   - cargo test --no-default-features

--- a/src/rrun.glade
+++ b/src/rrun.glade
@@ -1,0 +1,19 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!-- Generated with glade 3.19.0 -->
+<interface>
+  <requires lib="gtk+" version="3.16"/>
+  <object class="GtkWindow" id="rrun">
+    <property name="can_focus">False</property>
+    <property name="window_position">center</property>
+    <child>
+      <object class="GtkBox" id="container">
+        <property name="visible">True</property>
+        <property name="can_focus">False</property>
+        <property name="orientation">vertical</property>
+        <child>
+          <placeholder/>
+        </child>
+      </object>
+    </child>
+  </object>
+</interface>


### PR DESCRIPTION
This should make implementing #12 much easier :)
No changes to the UI yet.
Is the `search_entry` feature distinction important? If so, I can change the Glade file not to include the `Entry`/`SearchEntry` widget and add it from the code (as it was before).
