### PR TITLE
Another shot at a containerized Travis build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,18 +1,24 @@
 language: rust
-sudo: required
-dist: trusty
+sudo: false
 env:
   global:
     - LD_LIBRARY_PATH=/usr/local/lib
 rust:
   - nightly
   - stable
-before_install:
-  - sudo add-apt-repository -y ppa:gnome3-team/gnome3
-  - sudo add-apt-repository -y ppa:gnome3-team/gnome3-staging
-  - sudo apt-get update
-install:
-  - sudo apt-get install -y gtk+3.0 libgtk-3-dev
+
+addons:
+  apt:
+    packages:
+      - libgtk-3-dev
+
+env:
+  - PKG_CONFIG_PATH="$HOME/local/lib/pkgconfig"
+before_script:
+  - ./install_gtk.sh
+cache:
+  directories:
+  - $HOME/local
 script:
   - rustc --version
   - cargo test --no-default-features

--- a/install_gtk.sh
+++ b/install_gtk.sh
@@ -1,0 +1,10 @@
+#!/bin/sh
+
+set -x
+set -e
+
+WD="$PWD"
+cd "$HOME"
+curl -LO "https://github.com/gkoz/gtk-bootstrap/releases/download/gtk-3.18.1-2/deps.txz"
+tar xf deps.txz
+cd "$WD"


### PR DESCRIPTION
Ok, looks like we've got a winner: a container-based build using pre-compiled GTK binaries like they do in gtk-rs.
Passes the tests and runs much faster than the non-container build.
